### PR TITLE
Fix compatibility with Go 1.11

### DIFF
--- a/pageant_windows.go
+++ b/pageant_windows.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"sync"
 	. "syscall"
-	. "unsafe"
+	"unsafe"
 )
 
 // Maximum size of message can be sent to pageant
@@ -39,7 +39,7 @@ const (
 type copyData struct {
 	dwData uintptr
 	cbData uint32
-	lpData Pointer
+	lpData unsafe.Pointer
 }
 
 var (
@@ -96,7 +96,7 @@ func query(msg []byte) ([]byte, error) {
 	}
 	defer UnmapViewOfFile(ptr)
 
-	mmSlice := (*(*[MaxMessageLen]byte)(Pointer(ptr)))[:]
+	mmSlice := (*(*[MaxMessageLen]byte)(unsafe.Pointer(ptr)))[:]
 
 	copy(mmSlice, msg)
 
@@ -105,10 +105,10 @@ func query(msg []byte) ([]byte, error) {
 	cds := copyData{
 		dwData: agentCopydataID,
 		cbData: uint32(len(mapNameBytesZ)),
-		lpData: Pointer(&(mapNameBytesZ[0])),
+		lpData: unsafe.Pointer(&(mapNameBytesZ[0])),
 	}
 
-	resp, _, _ := winSendMessage(paWin, wmCopydata, 0, uintptr(Pointer(&cds)))
+	resp, _, _ := winSendMessage(paWin, wmCopydata, 0, uintptr(unsafe.Pointer(&cds)))
 
 	if resp == 0 {
 		return nil, ErrSendMessage
@@ -127,6 +127,6 @@ func query(msg []byte) ([]byte, error) {
 
 func pageantWindow() uintptr {
 	nameP, _ := UTF16PtrFromString("Pageant")
-	h, _, _ := winFindWindow(uintptr(Pointer(nameP)), uintptr(Pointer(nameP)))
+	h, _, _ := winFindWindow(uintptr(unsafe.Pointer(nameP)), uintptr(unsafe.Pointer(nameP)))
 	return h
 }


### PR DESCRIPTION
```
vendor/github.com/davidmz/go-pageant/pageant_windows.go:17:2: Pointer redeclared during import "unsafe"
	previous declaration during import "syscall"
vendor/github.com/davidmz/go-pageant/pageant_windows.go:17:2: imported and not used: "unsafe"
vendor/github.com/davidmz/go-pageant/pageant_windows.go:99:45: cannot convert ptr (type uintptr) to type syscall.Pointer
vendor/github.com/davidmz/go-pageant/pageant_windows.go:108:18: cannot convert &mapNameBytesZ[0] (type *byte) to type syscall.Pointer
vendor/github.com/davidmz/go-pageant/pageant_windows.go:111:68: cannot convert &cds (type *copyData) to type syscall.Pointer
vendor/github.com/davidmz/go-pageant/pageant_windows.go:130:42: cannot convert nameP (type *uint16) to type syscall.Pointer
```